### PR TITLE
環境変数の設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 - npm：8.5.4
 - yarn：1.22.19
 ## 環境構築
-- クローン
-
+### クローン
+```
 $ mkdir forPlapoApps
 
 $ cd forPlapoApps
@@ -17,8 +17,9 @@ $ cd forPlapoApps
 $ git clone https://github.com/forPlapoApps/client.git
 
 $ git clone https://github.com/forPlapoApps/server.git
+```
 
-- フロント
+### フロント
 ```
 $ cd client
 
@@ -36,7 +37,7 @@ SERVER_URL="http://localhost:8000"
 localhost:3000で起動
 
 
-- サーバー
+### サーバー
 
 ```
 $ cd server

--- a/README.md
+++ b/README.md
@@ -27,15 +27,14 @@ $ yarn install
 $ yarn dev
 ```
 
+```.env.local```ファイルを作成し、
+```
+SERVER_URL="http://localhost:8000"
+```
+と記述する。
+
 localhost:3000で起動
 
-```JSX
-// const url = "http://localhost:8000"
-const url = 'https://for-plapo-apps-server.herokuapp.com'
-↓
-const url = "http://localhost:8000"
-// const url = 'https://for-plapo-apps-server.herokuapp.com'
-```
 
 - サーバー
 

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: false,
   swcMinify: true,
+  env: { SERVER_URL: process.env.SERVER_URL }
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: false,
   swcMinify: true,
-  env: { SERVER_URL: process.env.SERVER_URL }
+  env: { SERVER_URL: process.env.SERVER_URL },
   images: {
     domains: ['cdn.devdojo.com'],
   },

--- a/pages/rooms/[uid].jsx
+++ b/pages/rooms/[uid].jsx
@@ -10,8 +10,7 @@ import { useRouter } from 'next/router'
 import Title from '../components/Title'
 import { useBeforeunload } from 'react-beforeunload'
 
-// const url = "http://localhost:8000"
-const url = 'https://for-plapo-apps-server.herokuapp.com'
+const url = process.env.SERVER_URL
 const socket = io(url, {
   closeOnBeforeunload: false,
 })


### PR DESCRIPTION
# やったこと
- client側で、serverの接続先を開発環境・本番環境ごとに変える
  - 開発環境は```http://localhost:8000```に（.env.localに記述）、
  - 本番環境は```https://for-plapo-apps-server.herokuapp.com```（vercelに設定済み）に
  接続する。

- それに伴うreadmeの更新

# 共有事項
マージしたら```.env.local```ファイルを作成しないと接続できなくなるので注意